### PR TITLE
Move to cargo-xbuild to be able to build 'alloc' crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The TMS570 family integrates dual Cortex-R4F and Cortex-R5F processors in lock-s
 
 ### Getting started
 
-1. Xargo v0.3.10
+1. Cargo xbuild installed (`cargo install cargo-xbuild`)
 2. Linaro Toolchain [armeb-none-eabi v7.2.x](https://releases.linaro.org/components/toolchain/binaries/latest/armeb-eabi/)
 3. rust nightly as default toolchain (`rustc 1.28.0-nightly (29f48ccf3 2018-06-03)` or newer)
 4. JTAG programmer: Lautherbach Trace32 Powerview for ARM or OpenOCD

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -4,7 +4,6 @@ MAKEFLAGS += -r
 MAKEFLAGS += -R
 
 TOOLCHAIN ?= armeb-eabi
-XARGO ?= xargo
 
 CC        := $(TOOLCHAIN)-gcc
 AR        := $(TOOLCHAIN)-ar
@@ -16,7 +15,6 @@ CFLAGS    := -O2 -march=armv7-r
 
 export CARGO_INCREMENTAL=0
 
-# Configure Xargo to use native compiler if needed
 # Used mainly to build compiler-builtins
 US:= _
 DASH:= -
@@ -69,7 +67,7 @@ target/$(TARGET)/release/$(PLATFORM).lst: target/$(TARGET)/release/$(PLATFORM).e
 
 .PHONY: target/$(TARGET)/release/$(PLATFORM)
 target/$(TARGET)/release/$(PLATFORM):
-	$(Q)RUSTFLAGS=$(RUSTFLAGS_LINK) $(XARGO) build --target=$(TARGET) $(VERBOSE) --release
+	$(Q)RUSTFLAGS=$(RUSTFLAGS_LINK) cargo xbuild --target=$(TARGET) $(VERBOSE) --release
 	$(Q)$(SIZE) $@
 
 target/$(TARGET)/debug/$(PLATFORM).elf: target/$(TARGET)/debug/$(PLATFORM)
@@ -77,16 +75,16 @@ target/$(TARGET)/debug/$(PLATFORM).elf: target/$(TARGET)/debug/$(PLATFORM)
 
 .PHONY: target/$(TARGET)/debug/$(PLATFORM)
 target/$(TARGET)/debug/$(PLATFORM):
-	$(Q)RUSTFLAGS=$(RUSTFLAGS_LINK) $(XARGO) build $(VERBOSE) --target=$(TARGET)
+	$(Q)RUSTFLAGS=$(RUSTFLAGS_LINK) cargo xbuild $(VERBOSE) --target=$(TARGET)
 	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > target/$(TARGET)/debug/$(PLATFORM).lst
 	$(Q)$(SIZE) $@
 
 .PHONY: check
 check:
-	$(Q)RUSTFLAGS=$(RUSTFLAGS_LINK) $(XARGO) check --target=$(TARGET) $(VERBOSE) --release
+	$(Q)RUSTFLAGS=$(RUSTFLAGS_LINK) cargo check --target=$(TARGET) $(VERBOSE) --release
 
 .PHONY: clean
 clean::
-	$(Q)$(XARGO) clean $(VERBOSE)
+	$(Q)cargo clean $(VERBOSE)
 
 

--- a/boards/ti_tms570/Cargo.lock
+++ b/boards/ti_tms570/Cargo.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "cc"
-version = "1.0.4"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -24,7 +24,7 @@ dependencies = [
 name = "tms570"
 version = "0.1.0"
 dependencies = [
- "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortexr4 0.1.0",
  "r0 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -36,6 +36,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
+"checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum r0 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
 "checksum vcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45c297f0afb6928cd08ab1ff9d95e99392595ea25ae1b5ecf822ff8764e57a0d"

--- a/boards/ti_tms570/Xargo.toml
+++ b/boards/ti_tms570/Xargo.toml
@@ -1,6 +1,0 @@
-[dependencies.core]
-stage = 0
-
-[dependencies.compiler_builtins]
-features = ["c"]
-stage = 1


### PR DESCRIPTION
The `compiler_builtins` crate is now explicitly injected.
When building the `alloc` crate via Xargo.toml, a “multiple matching crates for compiler_builtins” error occurs.
The reason is that `alloc` defines its own `compiler_builtins` dependency.
Thus  `compiler_builtins` in compiled twice, once as version 0.0.0 and once as version 0.1.0.

Move to `cargo-xbuild` to fix the issue