### PR TITLE
inline init_stack_pointers() to avoid recursive calls.

### DIFF
--- a/arch/cortex-r4/src/silicon.rs
+++ b/arch/cortex-r4/src/silicon.rs
@@ -6,14 +6,12 @@
 /// Workaround:
 ///     Disable out-of-order completion for divide instructions
 ///     (bit 7) in Auxiliary Control register
+#[inline]
 pub unsafe fn errata66() {
     asm!("
-        push {r0}
         mrc p15, #0, r0, c1, c0, #1
         orr r0, r0, #0x80
         mcr p15, #0, r0, c1, c0, #1
-        pop {r0}
-        bx lr
     "::: "memory" : "volatile");
 }
 
@@ -25,13 +23,11 @@ pub unsafe fn errata66() {
 /// Workaround:
 ///     Disable out-of-order single-precision floating point
 ///     multiply-accumulate instruction completion [BIT 16 (Set DOOFMACS)]
+#[inline]
 pub unsafe fn errata57() {
     asm!("
-        push {r0}
         mrc p15, #0, r0, c15, c0, #0
         orr r0, r0, #0x10000
         mcr p15, #0, r0, c15, c0, #0
-        pop {r0}
-        bx lr
     "::: "memory" : "volatile");
 }


### PR DESCRIPTION
As reported in #5 We need to avoid to the double call that, before stack initialization is completed, trigger a recursive calls to _cpu_stack().

For now just move back to hard-coded asm due to issue in _cpu_stack() when in release mode.

Tested in both debug and release mode on TMS570LS3132

Close #5 